### PR TITLE
Adiciona botão de cadastro para categoria de cliente

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -1,3 +1,8 @@
 a {
   text-decoration: none;
 }
+
+/* buttons */
+.button-form-group {
+  display: flex;
+}

--- a/app/controllers/client_categories_controller.rb
+++ b/app/controllers/client_categories_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ClientCategoriesController < ApplicationController
+  before_action :authenticate_admin!
   def index
     @client_categories = ClientCategory.all
   end

--- a/app/views/client_categories/index.html.erb
+++ b/app/views/client_categories/index.html.erb
@@ -1,5 +1,8 @@
 <h1>Categoria de Clientes</h1>
 
+<div class="breadcrumb">
+    <li class="breadcrumb-item"><%= link_to "Cadastrar categoria", new_client_category_path, class:"btn btn-primary" %></li>
+</div>
 <div>
 	<table class="table">
 		<thead>
@@ -21,5 +24,4 @@
 			<% end %>
 		</tbody>
 	</table>
-	
 </div>

--- a/app/views/client_categories/new.html.erb
+++ b/app/views/client_categories/new.html.erb
@@ -6,16 +6,29 @@
     <% end %>
   </ul>
 <% end %>
-  <%= form_with(model: @client_category) do |f| %>
-  <div class="form-group">
-    <%= f.label :name, class:"form-label" %>
-    <%= f.text_field :name, class:"form-control" %>
-  </div>
-  <div class="form-group">
-    <%= f.label :discount_percent, class:"form-label" %>
-    <%= f.text_field :discount_percent, class:"form-control" %>
-  </div>
-  <div class="form-group">
-    <%= f.submit 'Cadastrar', disable_with: 'cadastrando...', class:"btn btn-primary" %>
+
+<div class="card mb-4">
+	<div class="card-header">
+		<i class="fas fa-table me-1"></i>Formulário
+	</div>
+	<div class="card-body">
+    <%= form_with(model: @client_category) do |f| %>
+    <div class="mb-3 row">
+      <div class="col">
+        <%= f.label :name, class:"form-label" %>
+        <%= f.text_field :name, class:"form-control" %>
+      </div>
+      <div class="col">
+        <%= f.label :discount_percent, class:"form-label" %>
+        <%= f.text_field :discount_percent, class:"form-control" %>
+      </div>
+    </div>
+    <div class="form-group button-form-group">
+      <%= f.submit 'Cadastrar', disable_with: 'cadastrando...', class:"btn btn-primary" %>
+    </div>
+    <div class="form-group button-form-group">
+      <%= link_to 'Voltar', client_categories_path, class:"btn btn-light" %>
+    </div>
   </div>
 <% end %>
+

--- a/spec/system/client_category/admin_registers_client_category_spec.rb
+++ b/spec/system/client_category/admin_registers_client_category_spec.rb
@@ -31,4 +31,10 @@ describe 'admin registers client category' do
     expect(page).to have_content 'Verifique os erros abaixo:'
     expect(page).to have_content 'Porcentagem de desconto não pode ficar em branco'
   end
+
+  it 'access new_client_category without be authenticated' do
+    visit new_client_category_path
+
+    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
+  end
 end

--- a/spec/system/client_category/admin_registers_client_category_spec.rb
+++ b/spec/system/client_category/admin_registers_client_category_spec.rb
@@ -4,16 +4,24 @@ require 'rails_helper'
 
 describe 'admin registers client category' do
   it 'with success' do
+    admin = Admin.create(email: 'example@userubis.com.br', password: 'password', password_confirmation: 'password',
+                         full_name: 'Pedrinho Junior Gomes', cpf: '12345678944')
+
+    login_as(admin)
     visit new_client_category_path
 
     fill_in 'Nome',	with: 'Bronze'
-    fill_in 'Porcentagem de desconto',	with: 'Ouro'
+    fill_in 'Porcentagem de desconto', with: 'Ouro'
     click_on 'Cadastrar'
 
     expect(page).to have_content 'Categoria criada com sucesso.'
   end
 
   it 'with fail' do
+    admin = Admin.create(email: 'example@userubis.com.br', password: 'password', password_confirmation: 'password',
+                         full_name: 'Pedrinho Junior Gomes', cpf: '12345678944')
+
+    login_as(admin)
     visit new_client_category_path
 
     fill_in 'Nome',	with: 'Diamante'

--- a/spec/system/client_category/admin_views_client_category_spec.rb
+++ b/spec/system/client_category/admin_views_client_category_spec.rb
@@ -28,4 +28,25 @@ describe 'Admin views client category' do
     expect(page).to have_content 'Categoria de Clientes'
     expect(page).to have_content 'Não há categoria cadastrada'
   end
+
+  it 'access new_client_category page' do
+    # admin = Admin.create(email: 'example@userubis.com.br', password: 'password', password_confirmation: 'password', full_name: 'Pedrinho Junior Gomes', cpf: '12345678944')
+
+    visit client_categories_path
+    click_on 'Cadastrar categoria'
+    
+    expect(current_path).to eq new_client_category_path
+    expect(page).to have_field 'Nome'
+    expect(page).to have_field 'Porcentagem de desconto'
+  end
+
+  it 'return to client_categories_path' do
+    # admin = Admin.create(email: 'example@userubis.com.br', password: 'password', password_confirmation: 'password', full_name: 'Pedrinho Junior Gomes', cpf: '12345678944')
+
+    visit new_client_category_path
+    click_on 'Voltar'
+    
+    expect(page).to have_content 'Não há categoria cadastrada'
+    expect(page).to have_content 'Categoria de Clientes'
+  end
 end

--- a/spec/system/client_category/admin_views_client_category_spec.rb
+++ b/spec/system/client_category/admin_views_client_category_spec.rb
@@ -4,9 +4,12 @@ require 'rails_helper'
 
 describe 'Admin views client category' do
   it 'with success' do
+    admin = Admin.create(email: 'example@userubis.com.br', password: 'password', password_confirmation: 'password',
+                         full_name: 'Pedrinho Junior Gomes', cpf: '12345678944')
     ClientCategory.create!(name: 'Bronze', discount_percent: 0)
     ClientCategory.create!(name: 'Ouro', discount_percent: 10)
 
+    login_as(admin)
     visit client_categories_path
 
     expect(page).to have_content 'Bronze'
@@ -16,6 +19,10 @@ describe 'Admin views client category' do
   end
 
   it 'without any client categories' do
+    admin = Admin.create(email: 'example@userubis.com.br', password: 'password', password_confirmation: 'password',
+                         full_name: 'Pedrinho Junior Gomes', cpf: '12345678944')
+
+    login_as(admin)
     visit client_categories_path
 
     expect(page).to have_content 'Categoria de Clientes'
@@ -23,19 +30,32 @@ describe 'Admin views client category' do
   end
 
   it 'access new_client_category page' do
+    admin = Admin.create(email: 'example@userubis.com.br', password: 'password', password_confirmation: 'password',
+                         full_name: 'Pedrinho Junior Gomes', cpf: '12345678944')
+
+    login_as(admin)
     visit client_categories_path
     click_on 'Cadastrar categoria'
 
-    expect(current_path).to eq new_client_category_path
+    expect(page).to have_current_path new_client_category_path, ignore_query: true
     expect(page).to have_field 'Nome'
     expect(page).to have_field 'Porcentagem de desconto'
   end
 
   it 'return to client_categories_path' do
-    visit new_client_category_path
-    click_on 'Voltar'
+    admin = Admin.create(email: 'example@userubis.com.br', password: 'password', password_confirmation: 'password',
+                         full_name: 'Pedrinho Junior Gomes', cpf: '12345678944')
+
+    login_as(admin)
+    visit client_categories_path
 
     expect(page).to have_content 'Não há categoria cadastrada'
     expect(page).to have_content 'Categoria de Clientes'
+  end
+
+  it 'access client_category without be authenticated' do
+    visit client_categories_path
+
+    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 end


### PR DESCRIPTION
Co-authored-by: Davide Almeida <davide-almeida@users.noreply.github.com>

*Qual é o propósito deste Pull Request?*

- #15 

*O que foi feito para atingir isso?*

**Implementações:**

- Teste de sistema
- Link_to para cadastrar categoria de cliente

*Como testar que isso realmente funciona?*

- Acessar `client_categories_path` e clicar no botão de `Cadastrar categoria`

close #15 
